### PR TITLE
Add hotfix, which adds scalatest as a dependency for all modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,15 @@
 
     </properties>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.scalatest</groupId>
+			<artifactId>scalatest_2.13</artifactId>
+			<version>${scalatest.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
     <dependencyManagement>
         <dependencies>
 


### PR DESCRIPTION
This pull request shows the hot fix for this issue. However idealy the longer term solution would be for this to be fixed within the scalatest-maven-plugin