### PR TITLE
Testing 2.1.0-SNAP2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <junit.jupiter.version>5.5.0</junit.jupiter.version>
         <scalatest.version>3.2.0-M2</scalatest.version>
 
-        <scalatest.maven.plugin.version>2.0.0</scalatest.maven.plugin.version>
+        <scalatest.maven.plugin.version>2.1.0-SNAP2</scalatest.maven.plugin.version>
 
     </properties>
 
@@ -124,6 +124,9 @@
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
+                <!--<configuration>
+                    <noScalaTestIgnore>true</noScalaTestIgnore>
+                </configuration>-->
                 <executions>
                     <execution>
                         <id>test</id>


### PR DESCRIPTION
Switch to 2.1.0-SNAP2 and added noScalaTestIgnore (commented) for testing.

The error message now looks like: 

```
Error: Could not find or load main class org.scalatest.tools.Runner
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for ideal-scenario 1.0-SNAPSHOT:
[INFO] 
[INFO] ideal-scenario ..................................... FAILURE [  0.685 s]
[INFO] java-module ........................................ SKIPPED
[INFO] mixed-java-scala-module ............................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.756 s
[INFO] Finished at: 2022-07-06T11:51:49+08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.scalatest:scalatest-maven-plugin:2.1.0-SNAP2:test (test) on project ideal-scenario: Failure because ScalaTest not available on classpath. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

If you would like it to ignore when scalatest is not available, you can uncomment this part of code: 

https://github.com/stewartHutchins/scalatest-maven-plugin-bug-demo/compare/master...cheeseng:scalatest-maven-plugin-bug-demo:test-fix?expand=1#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R127
